### PR TITLE
Allow showing images on prompt page

### DIFF
--- a/prompt_routes.py
+++ b/prompt_routes.py
@@ -16,6 +16,7 @@ def prompt_page():
         if request.method == "POST"
         else request.args.get("folder", "")
     ).strip()
+    show = (request.form.get("show") or request.args.get("show")) is not None
     images, err = [], ""
     if folder:
         if not os.path.isdir(folder):
@@ -30,7 +31,9 @@ def prompt_page():
                         "prompt": prompt_from_meta(full) or "(no prompt)",
                     }
                 )
-    return render_template("prompt.html", folder=folder, images=images, error=err)
+    return render_template(
+        "prompt.html", folder=folder, images=images, error=err, show_images=show
+    )
 
 
 @prompt_bp.route("/sort", methods=["GET", "POST"])
@@ -38,9 +41,10 @@ def prompt_sort():
     if request.method == "GET":
         return redirect(url_for("prompt.prompt_page"))
     folder = request.form["folder"]
+    show = request.form.get("show")
     keys = [t.lower() for t in _SPLIT_RE.split(request.form["tags"]) if t]
     if not keys or not os.path.isdir(folder):
-        return redirect(url_for("prompt.prompt_page", folder=folder))
+        return redirect(url_for("prompt.prompt_page", folder=folder, show=show))
 
     for fn in image_files(folder):
         full = os.path.join(folder, fn)
@@ -51,4 +55,4 @@ def prompt_sort():
                 os.makedirs(dst, exist_ok=True)
                 shutil.move(full, os.path.join(dst, fn))
                 break
-    return redirect(url_for("prompt.prompt_page", folder=folder))
+    return redirect(url_for("prompt.prompt_page", folder=folder, show=show))

--- a/tagger_routes.py
+++ b/tagger_routes.py
@@ -25,6 +25,7 @@ def tagger_page():
         if request.method == "POST"
         else request.args.get("folder", "")
     ).strip()
+    show = (request.form.get("show") or request.args.get("show")) is not None
     images, err = [], ""
     if folder:
         if not os.path.isdir(folder):
@@ -33,7 +34,9 @@ def tagger_page():
             for fn in image_files(folder):
                 full = os.path.join(folder, fn)
                 images.append({"filename": fn, "full_path": full})
-    return render_template("tagger.html", folder=folder, images=images, error=err)
+    return render_template(
+        "tagger.html", folder=folder, images=images, error=err, show_images=show
+    )
 
 
 @tagger_bp.route("/sort", methods=["POST"])

--- a/templates/prompt.html
+++ b/templates/prompt.html
@@ -25,6 +25,7 @@
 <!-- Folder scan form -->
 <form method="POST">
   <input type="text" name="folder" placeholder="Full path to image folder" value="{{ folder }}"><br>
+  <label><input type="checkbox" name="show" value="1" {% if show_images %}checked{% endif %}> Show images</label><br>
   <input type="submit" value="Scan">
 </form>
 
@@ -36,6 +37,7 @@
 <!-- Sorting by tag form -->
 <form method="POST" action="{{ url_for('prompt.prompt_sort') }}">
   <input type="hidden" name="folder" value="{{ folder }}">
+  {% if show_images %}<input type="hidden" name="show" value="1">{% endif %}
   <label>Move images whose <strong>prompt</strong> contains:</label><br>
   <input type="text" name="tags" placeholder="e.g. cirno, dragon"><br>
   <input type="submit" value="Sort Images">
@@ -45,8 +47,9 @@
 <div class="grid">
   {% for img in images %}
     <div class="card" onclick="showPrompt('{{ img.full_path | urlencode }}')">
-      <img src="{{ url_for('serve_image') }}?path={{ img.full_path | urlencode }}"
-           alt="{{ img.filename }}">
+      {% if show_images %}
+      <img src="{{ url_for('serve_image') }}?path={{ img.full_path | urlencode }}" alt="{{ img.filename }}">
+      {% endif %}
       <div class="filename">{{ img.filename }}</div>
     </div>
   {% endfor %}

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -27,6 +27,7 @@
 
 <form method="POST">
   <input type="text" name="folder" placeholder="Full path to image folder" value="{{ folder }}"><br>
+  <label><input type="checkbox" name="show" value="1" {% if show_images %}checked{% endif %}> Show images</label><br>
   <input type="submit" value="Scan">
 </form>
 
@@ -46,7 +47,9 @@
 <div class="grid" id="grid">
   {% for img in images %}
     <div class="card" data-path="{{ img.full_path | urlencode }}">
+      {% if show_images %}
       <img src="{{ url_for('serve_image') }}?path={{ img.full_path | urlencode }}" alt="{{ img.filename }}">
+      {% endif %}
       <div class="tags">loading…</div>
       <div class="filename">{{ img.filename }}</div>
     </div>


### PR DESCRIPTION
## Summary
- add checkbox to show images on prompt organizer
- preserve `show` parameter when sorting
- expose `show_images` flag in template
- allow hiding images on tagger page

## Testing
- `python -m py_compile app.py prompt_routes.py tagger_routes.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce66605608330839f1598004170e2