### PR TITLE
Add rating organizer page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,11 +2,13 @@ from flask import Flask, render_template, request, send_file
 import urllib.parse
 from prompt_routes import prompt_bp
 from tagger_routes import tagger_bp
+from rating_routes import rating_bp
 from utils import prompt_from_meta
 
 app = Flask(__name__)
 app.register_blueprint(prompt_bp)
 app.register_blueprint(tagger_bp)
+app.register_blueprint(rating_bp)
 
 
 @app.route("/")

--- a/rating_routes.py
+++ b/rating_routes.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import urllib.parse
+from flask import Blueprint, render_template, request, jsonify, redirect, url_for
+
+from utils import rating_of_image, image_files, safe
+
+rating_bp = Blueprint('rating', __name__, url_prefix='/rating')
+
+
+@rating_bp.route('/', methods=['GET', 'POST'])
+def rating_page():
+    folder = (
+        request.form.get('folder', '') if request.method == 'POST' else request.args.get('folder', '')
+    ).strip()
+    show = (request.form.get('show') or request.args.get('show')) is not None
+    images, err = [], ''
+    if folder:
+        if not os.path.isdir(folder):
+            err, folder = 'Invalid folder path.', ''
+        else:
+            for fn in image_files(folder):
+                full = os.path.join(folder, fn)
+                images.append({'filename': fn, 'full_path': full})
+    return render_template('rating.html', folder=folder, images=images, error=err, show_images=show)
+
+
+@rating_bp.route('/sort', methods=['POST'])
+def rating_sort():
+    folder = request.form['folder']
+    moved = []
+    if not os.path.isdir(folder):
+        return jsonify({'moved': moved})
+
+    for fn in image_files(folder):
+        full = os.path.join(folder, fn)
+        try:
+            cls = rating_of_image(full)
+        except Exception:
+            continue
+        dst = os.path.join(folder, safe(cls))
+        os.makedirs(dst, exist_ok=True)
+        shutil.move(full, os.path.join(dst, fn))
+        moved.append(urllib.parse.quote_plus(full))
+
+    return jsonify({'moved': moved})
+
+
+@rating_bp.route('/api/rating', methods=['POST'])
+def api_rating():
+    path = urllib.parse.unquote(request.form['path'])
+    try:
+        cls = rating_of_image(path)
+        return (cls, 200, {'Content-Type': 'text/plain; charset=utf-8'})
+    except Exception as e:
+        return (str(e), 500)

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,5 +36,6 @@
   <h1>🧠 Stable Diffusion Image Organizer</h1>
   <a class="btn" href="{{ url_for('prompt.prompt_page') }}">📄 Prompt Organiser</a>
   <a class="btn" href="{{ url_for('tagger.tagger_page') }}">🏷️ WD-Tagger Organiser</a>
+  <a class="btn" href="{{ url_for('rating.rating_page') }}">🔞 Rating Organiser</a>
 </body>
 </html>

--- a/templates/rating.html
+++ b/templates/rating.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Rating Organiser</title>
+<style>
+  body { background: #111; color: #eee; font-family: sans-serif; padding: 2em; }
+  a { color: #4af; }
+  input[type=text] { padding: .4em; width: 80%; max-width: 600px; margin: .3em 0; }
+  button, input[type=submit] { padding: .5em 1.2em; margin: .3em 0; }
+  .grid { display: flex; flex-wrap: wrap; gap: 1em; margin-top: 1.5em; }
+  .card { background: #222; padding: 1em; border: 1px solid #444; width: 200px; cursor: pointer; }
+  .card img { max-width: 100%; border: 1px solid #333; }
+  .rating { font-size: .8em; color: #ccc; margin-top: .4em; opacity: 0; transition: opacity .4s; }
+  .rating.visible { opacity: 1; }
+  .filename { margin-top: .4em; font-size: .8em; word-break: break-word; }
+  #barWrap { display: none; margin-top: 1rem; width: 100%; max-width: 600px; height: 10px; background: #333; border-radius: 5px; overflow: hidden; }
+  #bar { height: 100%; width: 0%; background: #4af; }
+  #eta { font-size: .8em; color: #aaa; margin-top: .3em; }
+</style>
+</head>
+<body>
+
+<h1>🔞 Rating Organiser</h1>
+<p>
+  <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
+  <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a>
+</p>
+
+<form method="POST">
+  <input type="text" name="folder" placeholder="Full path to image folder" value="{{ folder }}"><br>
+  <label><input type="checkbox" name="show" value="1" {% if show_images %}checked{% endif %}> Show images</label><br>
+  <input type="submit" value="Scan">
+</form>
+
+{% if error %}<p style="color:#f66">{{ error }}</p>{% endif %}
+
+{% if images %}
+<div style="margin-top:1rem">
+  <button id="sortBtn">Sort by rating</button>
+</div>
+
+<div id="barWrap"><div id="bar"></div></div>
+<div id="eta"></div>
+
+<div class="grid" id="grid">
+  {% for img in images %}
+    <div class="card" data-path="{{ img.full_path | urlencode }}">
+      {% if show_images %}
+      <img src="{{ url_for('serve_image') }}?path={{ img.full_path | urlencode }}" alt="{{ img.filename }}">
+      {% endif %}
+      <div class="rating">loading…</div>
+      <div class="filename">{{ img.filename }}</div>
+    </div>
+  {% endfor %}
+</div>
+{% endif %}
+
+<script>
+const cards = [...document.querySelectorAll('.card')];
+const total = cards.length;
+let done = 0, start = Date.now();
+
+function loadRating(card){
+  const path = card.dataset.path;
+  const box = card.querySelector('.rating');
+  fetch('{{ url_for("rating.api_rating") }}', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `path=${path}`
+  })
+  .then(r => r.text())
+  .then(txt => { box.textContent = txt; box.classList.add('visible'); tick(); })
+  .catch(()=>{ box.textContent = '[error]'; tick(); });
+}
+
+function tick(){
+  done++;
+  const percent = done/total*100;
+  document.getElementById('bar').style.width = percent + '%';
+  if(done===total){
+    document.getElementById('eta').textContent = 'Rating complete.';
+  }else{
+    const eta = ((Date.now()-start)/1000/done*(total-done)).toFixed(1);
+    document.getElementById('eta').textContent = `Processed ${done}/${total} — ETA ${eta}s`;
+  }
+}
+
+if(total>0){
+  document.getElementById('barWrap').style.display='block';
+  cards.forEach(loadRating);
+}
+
+document.getElementById('sortBtn')?.addEventListener('click', e => {
+  e.preventDefault();
+  fetch('{{ url_for("rating.rating_sort") }}', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `folder={{ folder | urlencode }}`
+  })
+  .then(r => r.json())
+  .then(res => {
+    res.moved.forEach(p => {
+      const el = document.querySelector(`.card[data-path="${p}"]`);
+      if(el) el.remove();
+    });
+  });
+});
+</script>
+
+</body>
+</html>

--- a/utils.py
+++ b/utils.py
@@ -71,3 +71,17 @@ def prompt_from_meta(path: str):
     except Exception:
         pass
     return None
+
+@lru_cache(maxsize=512)
+def _cached_rating(path: str, mtime: float) -> str:
+    rating, _, _ = get_wd14_tags(path, MODEL_NAME)
+    return max(rating, key=rating.get)
+
+
+def rating_of_image(path: str) -> str:
+    """Return rating class for *path*, caching results by modification time."""
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        mtime = 0
+    return _cached_rating(path, mtime)


### PR DESCRIPTION
## Summary
- organize by WD14 rating tags (general/questionable/sensitive/explicit)
- new blueprint `rating_bp`
- new template `rating.html`
- link Rating Organiser from index

## Testing
- `python -m py_compile app.py prompt_routes.py tagger_routes.py rating_routes.py utils.py wd_batch_tagger.py`

------
https://chatgpt.com/codex/tasks/task_e_684cfc1c06308330989d0b724e0507e1