### PR TITLE
Auto move image after rating

### DIFF
--- a/rating_routes.py
+++ b/rating_routes.py
@@ -49,8 +49,13 @@ def rating_sort():
 @rating_bp.route('/api/rating', methods=['POST'])
 def api_rating():
     path = urllib.parse.unquote(request.form['path'])
+    move = request.form.get('move')
     try:
         cls = rating_of_image(path)
+        if move:
+            dst = os.path.join(os.path.dirname(path), safe(cls))
+            os.makedirs(dst, exist_ok=True)
+            shutil.move(path, os.path.join(dst, os.path.basename(path)))
         return (cls, 200, {'Content-Type': 'text/plain; charset=utf-8'})
     except Exception as e:
         return (str(e), 500)

--- a/templates/rating.html
+++ b/templates/rating.html
@@ -36,9 +36,7 @@
 {% if error %}<p style="color:#f66">{{ error }}</p>{% endif %}
 
 {% if images %}
-<div style="margin-top:1rem">
-  <button id="sortBtn">Sort by rating</button>
-</div>
+  <!-- Images will be moved automatically once rated -->
 
 <div id="barWrap"><div id="bar"></div></div>
 <div id="eta"></div>
@@ -67,11 +65,16 @@ function loadRating(card){
   fetch('{{ url_for("rating.api_rating") }}', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `path=${path}`
+    body: `path=${path}&move=1`
   })
   .then(r => r.text())
-  .then(txt => { box.textContent = txt; box.classList.add('visible'); tick(); })
-  .catch(()=>{ box.textContent = '[error]'; tick(); });
+  .then(txt => {
+    box.textContent = txt;
+    box.classList.add('visible');
+    setTimeout(() => card.remove(), 300);
+    tick();
+  })
+  .catch(() => { box.textContent = '[error]'; tick(); });
 }
 
 function tick(){
@@ -91,21 +94,6 @@ if(total>0){
   cards.forEach(loadRating);
 }
 
-document.getElementById('sortBtn')?.addEventListener('click', e => {
-  e.preventDefault();
-  fetch('{{ url_for("rating.rating_sort") }}', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `folder={{ folder | urlencode }}`
-  })
-  .then(r => r.json())
-  .then(res => {
-    res.moved.forEach(p => {
-      const el = document.querySelector(`.card[data-path="${p}"]`);
-      if(el) el.remove();
-    });
-  });
-});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- add optional move functionality to rating API
- automatically move images after rating is determined and remove manual sort

## Testing
- `python -m py_compile rating_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684d05f99834833080187fc4a06ea96f