### PR TITLE
Auto move image after rating

### DIFF
--- a/rating_routes.py
+++ b/rating_routes.py
@@ -3,7 +3,7 @@ import shutil
 import urllib.parse
 from flask import Blueprint, render_template, request, jsonify, redirect, url_for
 
-from utils import rating_of_image, image_files, safe
+from utils import rating_of_image, image_files, safe, walk_images
 
 rating_bp = Blueprint('rating', __name__, url_prefix='/rating')
 
@@ -19,9 +19,10 @@ def rating_page():
         if not os.path.isdir(folder):
             err, folder = 'Invalid folder path.', ''
         else:
-            for fn in image_files(folder):
-                full = os.path.join(folder, fn)
-                images.append({'filename': fn, 'full_path': full})
+            for full in walk_images(
+                folder, ignore=['questionable', 'explicit', 'sensitive', 'general']
+            ):
+                images.append({'filename': os.path.relpath(full, folder), 'full_path': full})
     return render_template('rating.html', folder=folder, images=images, error=err, show_images=show)
 
 
@@ -32,15 +33,16 @@ def rating_sort():
     if not os.path.isdir(folder):
         return jsonify({'moved': moved})
 
-    for fn in image_files(folder):
-        full = os.path.join(folder, fn)
+    for full in walk_images(
+        folder, ignore=['questionable', 'explicit', 'sensitive', 'general']
+    ):
         try:
             cls = rating_of_image(full)
         except Exception:
             continue
-        dst = os.path.join(folder, safe(cls))
+        dst = os.path.join(os.path.dirname(full), safe(cls))
         os.makedirs(dst, exist_ok=True)
-        shutil.move(full, os.path.join(dst, fn))
+        shutil.move(full, os.path.join(dst, os.path.basename(full)))
         moved.append(urllib.parse.quote_plus(full))
 
     return jsonify({'moved': moved})
@@ -49,8 +51,13 @@ def rating_sort():
 @rating_bp.route('/api/rating', methods=['POST'])
 def api_rating():
     path = urllib.parse.unquote(request.form['path'])
+    move = request.form.get('move')
     try:
         cls = rating_of_image(path)
+        if move:
+            dst = os.path.join(os.path.dirname(path), safe(cls))
+            os.makedirs(dst, exist_ok=True)
+            shutil.move(path, os.path.join(dst, os.path.basename(path)))
         return (cls, 200, {'Content-Type': 'text/plain; charset=utf-8'})
     except Exception as e:
         return (str(e), 500)

--- a/templates/rating.html
+++ b/templates/rating.html
@@ -36,9 +36,7 @@
 {% if error %}<p style="color:#f66">{{ error }}</p>{% endif %}
 
 {% if images %}
-<div style="margin-top:1rem">
-  <button id="sortBtn">Sort by rating</button>
-</div>
+  <!-- Images will be moved automatically once rated -->
 
 <div id="barWrap"><div id="bar"></div></div>
 <div id="eta"></div>
@@ -67,11 +65,16 @@ function loadRating(card){
   fetch('{{ url_for("rating.api_rating") }}', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `path=${path}`
+    body: `path=${path}&move=1`
   })
   .then(r => r.text())
-  .then(txt => { box.textContent = txt; box.classList.add('visible'); tick(); })
-  .catch(()=>{ box.textContent = '[error]'; tick(); });
+  .then(txt => {
+    box.textContent = txt;
+    box.classList.add('visible');
+    setTimeout(() => card.remove(), 300);
+    tick();
+  })
+  .catch(() => { box.textContent = '[error]'; tick(); });
 }
 
 function tick(){
@@ -91,21 +94,6 @@ if(total>0){
   cards.forEach(loadRating);
 }
 
-document.getElementById('sortBtn')?.addEventListener('click', e => {
-  e.preventDefault();
-  fetch('{{ url_for("rating.rating_sort") }}', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: `folder={{ folder | urlencode }}`
-  })
-  .then(r => r.json())
-  .then(res => {
-    res.moved.forEach(p => {
-      const el = document.querySelector(`.card[data-path="${p}"]`);
-      if(el) el.remove();
-    });
-  });
-});
 </script>
 
 </body>

--- a/utils.py
+++ b/utils.py
@@ -33,6 +33,16 @@ def image_files(folder: str) -> Iterable[str]:
             yield entry.name
 
 
+def walk_images(folder: str, ignore: Iterable[str] = ()) -> Iterable[str]:
+    """Yield image file paths under *folder* recursively, skipping *ignore* dirs."""
+    skip = {d.lower() for d in ignore}
+    for root, dirs, files in os.walk(folder):
+        dirs[:] = [d for d in dirs if d.lower() not in skip]
+        for fn in files:
+            if os.path.splitext(fn)[1].lower() in ALLOWED_EXT:
+                yield os.path.join(root, fn)
+
+
 @lru_cache(maxsize=512)
 def _cached_tags(path: str, mtime: float) -> List[str]:
     rating, feats, chars = get_wd14_tags(path, MODEL_NAME)


### PR DESCRIPTION
## Summary
- add recursive image walker and skip existing rating folders
- update rating organizer to use recursive search and move images in place

## Testing
- `python -m py_compile rating_routes.py`
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684d05f99834833080187fc4a06ea96f