### PR TITLE
Add metadata extraction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ The image organization script scans a specified source folder for images and mov
 - **Keywords**: 
   - You can customize the list of keywords to categorize images. Currently, the script includes a placeholder for a keyword ("cirno").
 
+### extract_metadata.py
+
+- **Functionality**:
+  - Recursively scans a folder for PNG files.
+  - Extracts all available metadata from each image.
+  - Saves the metadata to JSON files under a destination directory organised by rating (`general`, `sensitive`, `questionable`, `explicit`).
+- **Usage**:
+  - `python extract_metadata.py /path/to/images /path/to/output`
+
+### Web Metadata Page
+
+- Use the `/metadata/` page in the web interface to run the extraction
+  without the command line. Provide a source folder and destination directory,
+  then click **Extract** to save JSON files grouped by rating.
+
 ### Metadata Extraction
 
 - The script is capable of extracting the "prompts" metadata field from image files using the `exifread` library. This metadata can then be used to categorize images if no specific keyword match occurs.

--- a/app.py
+++ b/app.py
@@ -3,12 +3,14 @@ import urllib.parse
 from prompt_routes import prompt_bp
 from tagger_routes import tagger_bp
 from rating_routes import rating_bp
+from metadata_routes import metadata_bp
 from utils import prompt_from_meta
 
 app = Flask(__name__)
 app.register_blueprint(prompt_bp)
 app.register_blueprint(tagger_bp)
 app.register_blueprint(rating_bp)
+app.register_blueprint(metadata_bp)
 
 
 @app.route("/")

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Extract metadata from PNG images and organize by rating."""
+
+import argparse
+import json
+import os
+from typing import Dict, Any
+
+from PIL import Image, ExifTags
+
+from utils import rating_of_image, safe
+
+
+def read_metadata(path: str) -> Dict[str, Any]:
+    """Return all metadata found in *path* as a dictionary."""
+    data = {}
+    try:
+        with Image.open(path) as im:
+            data.update(im.info)
+            try:
+                exif = im.getexif()
+            except Exception:
+                exif = None
+            if exif:
+                tag_map = {ExifTags.TAGS.get(k, k): exif.get(k) for k in exif}
+                data["EXIF"] = tag_map
+    except Exception as e:
+        data["error"] = str(e)
+    return data
+
+
+def process(folder: str, out_dir: str) -> None:
+    """Walk *folder* and save metadata to *out_dir* grouped by rating."""
+    classes = ["general", "sensitive", "questionable", "explicit"]
+    for cls in classes:
+        os.makedirs(os.path.join(out_dir, safe(cls)), exist_ok=True)
+
+    for root, _, files in os.walk(folder):
+        for name in files:
+            if os.path.splitext(name)[1].lower() == ".png":
+                path = os.path.join(root, name)
+                try:
+                    rating = rating_of_image(path)
+                except Exception:
+                    rating = "general"
+                meta = read_metadata(path)
+                base = os.path.splitext(os.path.basename(path))[0]
+                dst = os.path.join(out_dir, safe(rating), safe(base) + ".json")
+                with open(dst, "w", encoding="utf-8") as f:
+                    json.dump(meta, f, indent=2, ensure_ascii=False)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("folder", help="Folder containing PNG images")
+    p.add_argument("out", help="Destination directory for metadata files")
+    args = p.parse_args()
+    process(args.folder, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/metadata_routes.py
+++ b/metadata_routes.py
@@ -1,0 +1,33 @@
+from flask import Blueprint, render_template, request
+import os
+
+import extract_metadata
+
+metadata_bp = Blueprint("metadata", __name__, url_prefix="/metadata")
+
+
+@metadata_bp.route("/", methods=["GET", "POST"])
+def metadata_page():
+    folder = (
+        request.form.get("folder", "")
+        if request.method == "POST"
+        else request.args.get("folder", "")
+    ).strip()
+    out = (
+        request.form.get("out", "")
+        if request.method == "POST"
+        else request.args.get("out", "")
+    ).strip()
+    message = ""
+    if request.method == "POST":
+        if not os.path.isdir(folder):
+            message = "Invalid source folder."
+        elif not out:
+            message = "Please specify output folder."
+        else:
+            try:
+                extract_metadata.process(folder, out)
+                message = "Metadata extraction complete."
+            except Exception as e:
+                message = str(e)
+    return render_template("metadata.html", folder=folder, out=out, message=message)

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,5 +37,6 @@
   <a class="btn" href="{{ url_for('prompt.prompt_page') }}">📄 Prompt Organiser</a>
   <a class="btn" href="{{ url_for('tagger.tagger_page') }}">🏷️ WD-Tagger Organiser</a>
   <a class="btn" href="{{ url_for('rating.rating_page') }}">🔞 Rating Organiser</a>
+  <a class="btn" href="{{ url_for('metadata.metadata_page') }}">📥 Metadata Extractor</a>
 </body>
 </html>

--- a/templates/metadata.html
+++ b/templates/metadata.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Metadata Extractor</title>
+<style>
+  body { background: #111; color: #eee; font-family: sans-serif; padding: 2em; }
+  a { color: #4af; }
+  input[type=text] { padding: .4em; width: 80%; max-width: 600px; margin: .3em 0; }
+  input[type=submit] { padding: .5em 1.2em; margin: .3em 0; }
+</style>
+</head>
+<body>
+
+<h1>📥 Metadata Extractor</h1>
+<p>
+  <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
+  <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a> |
+  <a href="{{ url_for('rating.rating_page') }}">Switch to Rating Organiser</a>
+</p>
+
+<form method="POST">
+  <input type="text" name="folder" placeholder="Image folder" value="{{ folder }}"><br>
+  <input type="text" name="out" placeholder="Destination folder" value="{{ out }}"><br>
+  <input type="submit" value="Extract">
+</form>
+
+{% if message %}<p>{{ message }}</p>{% endif %}
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include a new blueprint `metadata_routes.py`
- register the blueprint in `app.py`
- add a `metadata.html` template and link from the index
- document the new web page in the README

## Testing
- `black metadata_routes.py app.py -q`
- `ruff check metadata_routes.py app.py -q`
- `mypy metadata_routes.py app.py --ignore-missing-imports`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850fefbedf08330a4404d29888f127e