### PR TITLE
Enhance metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The image organization script scans a specified source folder for images and mov
 To run this script, you'll need the following Python libraries:
 
 ```bash
-pip install pillow exifread
+pip install pillow exifread tqdm
 ```
 
 ## Configuration

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -6,6 +6,8 @@ import json
 import os
 from typing import Dict, Any
 
+from tqdm import tqdm
+
 from PIL import Image, ExifTags
 
 from utils import rating_of_image, safe
@@ -35,19 +37,32 @@ def process(folder: str, out_dir: str) -> None:
     for cls in classes:
         os.makedirs(os.path.join(out_dir, safe(cls)), exist_ok=True)
 
+    paths = []
     for root, _, files in os.walk(folder):
         for name in files:
             if os.path.splitext(name)[1].lower() == ".png":
-                path = os.path.join(root, name)
-                try:
-                    rating = rating_of_image(path)
-                except Exception:
-                    rating = "general"
-                meta = read_metadata(path)
-                base = os.path.splitext(os.path.basename(path))[0]
-                dst = os.path.join(out_dir, safe(rating), safe(base) + ".json")
-                with open(dst, "w", encoding="utf-8") as f:
-                    json.dump(meta, f, indent=2, ensure_ascii=False)
+                paths.append(os.path.join(root, name))
+
+    for path in tqdm(paths, desc="Extracting metadata"):
+        try:
+            rating = rating_of_image(path)
+        except Exception:
+            rating = "general"
+        meta = read_metadata(path)
+        base = os.path.splitext(os.path.basename(path))[0]
+        dst_dir = os.path.join(out_dir, safe(rating))
+        base_safe = safe(base)
+        dst = os.path.join(dst_dir, base_safe + ".json")
+        if os.path.exists(dst):
+            i = 1
+            while True:
+                alt = os.path.join(dst_dir, f"{base_safe} ({i}).json")
+                if not os.path.exists(alt):
+                    dst = alt
+                    break
+                i += 1
+        with open(dst, "w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2, ensure_ascii=False)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add tqdm progress bar to metadata extraction
- avoid overwriting metadata files when names collide
- note tqdm in requirements list

## Testing
- `python -m py_compile extract_metadata.py`
- `python -m py_compile app.py metadata_routes.py prompt_routes.py rating_routes.py tagger_routes.py wd_batch_tagger.py utils.py`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6851138c899083309b4adfa591f9061d