### PR TITLE
Enhance metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The image organization script scans a specified source folder for images and mov
 
 - Use the `/metadata/` page in the web interface to run the extraction
   without the command line. Provide a source folder and destination directory,
-  then click **Extract** to save JSON files grouped by rating.
+  then click **Extract** to save JSON files grouped by rating. The page
+  displays a progress bar as each file is processed.
 
 ### Metadata Extraction
 
@@ -41,7 +42,7 @@ The image organization script scans a specified source folder for images and mov
 To run this script, you'll need the following Python libraries:
 
 ```bash
-pip install pillow exifread
+pip install pillow exifread tqdm
 ```
 
 ## Configuration

--- a/metadata_routes.py
+++ b/metadata_routes.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, render_template, request
+from flask import Blueprint, render_template, request, jsonify
+import urllib.parse
 import os
 
 import extract_metadata
@@ -31,3 +32,26 @@ def metadata_page():
             except Exception as e:
                 message = str(e)
     return render_template("metadata.html", folder=folder, out=out, message=message)
+
+
+@metadata_bp.route("/api/list", methods=["POST"])
+def api_list():
+    folder = request.form["folder"]
+    paths = []
+    if os.path.isdir(folder):
+        for root, _, files in os.walk(folder):
+            for name in files:
+                if os.path.splitext(name)[1].lower() == ".png":
+                    paths.append(os.path.join(root, name))
+    return jsonify({"paths": paths})
+
+
+@metadata_bp.route("/api/extract", methods=["POST"])
+def api_extract():
+    path = urllib.parse.unquote(request.form["path"])
+    out = request.form["out"]
+    try:
+        extract_metadata.process_single(path, out)
+        return ("ok", 200, {"Content-Type": "text/plain; charset=utf-8"})
+    except Exception as e:
+        return (str(e), 500)

--- a/templates/metadata.html
+++ b/templates/metadata.html
@@ -8,6 +8,9 @@
   a { color: #4af; }
   input[type=text] { padding: .4em; width: 80%; max-width: 600px; margin: .3em 0; }
   input[type=submit] { padding: .5em 1.2em; margin: .3em 0; }
+  #barWrap { display:none; margin-top:1rem; width:100%; max-width:600px; height:10px; background:#333; border-radius:5px; overflow:hidden; }
+  #bar { height:100%; width:0%; background:#4af; }
+  #eta { font-size:.8em; color:#aaa; margin-top:.3em; }
 </style>
 </head>
 <body>
@@ -25,7 +28,49 @@
   <input type="submit" value="Extract">
 </form>
 
+<div id="barWrap"><div id="bar"></div></div>
+<div id="eta"></div>
+
 {% if message %}<p>{{ message }}</p>{% endif %}
 
+<script>
+document.querySelector('form').onsubmit = async e => {
+  e.preventDefault();
+  const folder = e.target.folder.value.trim();
+  const out = e.target.out.value.trim();
+  if(!folder || !out) return;
+
+  const listRes = await fetch('{{ url_for("metadata.api_list") }}', {
+    method:'POST',
+    headers:{'Content-Type':'application/x-www-form-urlencoded'},
+    body:`folder=${encodeURIComponent(folder)}`
+  });
+  const data = await listRes.json();
+  const paths = data.paths;
+  const total = paths.length;
+  if(total === 0){
+    document.getElementById('eta').textContent = 'No images found.';
+    return;
+  }
+  document.getElementById('barWrap').style.display = 'block';
+  let done = 0, start = Date.now();
+  for(const p of paths){
+    await fetch('{{ url_for("metadata.api_extract") }}', {
+      method:'POST',
+      headers:{'Content-Type':'application/x-www-form-urlencoded'},
+      body:`path=${encodeURIComponent(p)}&out=${encodeURIComponent(out)}`
+    });
+    done++;
+    const percent = done/total*100;
+    document.getElementById('bar').style.width = percent + '%';
+    if(done===total){
+      document.getElementById('eta').textContent = 'Metadata extraction complete.';
+    }else{
+      const eta = ((Date.now()-start)/1000/done*(total-done)).toFixed(1);
+      document.getElementById('eta').textContent = `Processed ${done}/${total} — ETA ${eta}s`;
+    }
+  }
+};
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add tqdm progress bar to metadata extraction
- avoid overwriting metadata files when names collide
- display progress bar on metadata web page
- note tqdm in requirements list

## Testing
- `python -m py_compile extract_metadata.py app.py metadata_routes.py prompt_routes.py rating_routes.py tagger_routes.py wd_batch_tagger.py utils.py`
- `flake8 || true`


------
https://chatgpt.com/codex/tasks/task_e_6851138c899083309b4adfa591f9061d