### PR TITLE
Add batch wd-tagger page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The image organization script scans a specified source folder for images and mov
   without the command line. Provide a source folder and destination directory,
   then click **Extract** to save JSON files grouped by rating.
 
+### Batch WD-Tagger Page
+
+- The `/batch/` page tags all images under a folder (including subfolders) using
+  the WD-14 tagger.
+- Tags are saved as `.txt` files next to each image and a `tags.json` file is
+  created in the chosen output directory.
+
 ### Metadata Extraction
 
 - The script is capable of extracting the "prompts" metadata field from image files using the `exifread` library. This metadata can then be used to categorize images if no specific keyword match occurs.

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from prompt_routes import prompt_bp
 from tagger_routes import tagger_bp
 from rating_routes import rating_bp
 from metadata_routes import metadata_bp
+from dir_tagger_routes import batch_bp
 from utils import prompt_from_meta
 
 app = Flask(__name__)
@@ -11,6 +12,7 @@ app.register_blueprint(prompt_bp)
 app.register_blueprint(tagger_bp)
 app.register_blueprint(rating_bp)
 app.register_blueprint(metadata_bp)
+app.register_blueprint(batch_bp)
 
 
 @app.route("/")

--- a/dir_tagger_routes.py
+++ b/dir_tagger_routes.py
@@ -1,0 +1,58 @@
+from flask import Blueprint, render_template, request
+import os
+import json
+from tqdm import tqdm
+
+from utils import tag_image, walk_images
+
+batch_bp = Blueprint("batch", __name__, url_prefix="/batch")
+
+
+def process(folder: str, out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    out_json = os.path.join(out_dir, "tags.json")
+    try:
+        with open(out_json, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        data = {}
+
+    paths = list(walk_images(folder))
+    for path in tqdm(paths, desc="Tagging images"):
+        txt = os.path.splitext(path)[0] + ".txt"
+        if os.path.exists(txt):
+            continue
+        try:
+            tags = tag_image(path)
+        except Exception:
+            continue
+        with open(txt, "w", encoding="utf-8") as f:
+            f.write(", ".join(tags))
+        rel = os.path.relpath(path, folder)
+        data[rel] = tags
+
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+@batch_bp.route("/", methods=["GET", "POST"])
+def batch_page():
+    folder = (
+        request.form.get("folder", "") if request.method == "POST" else request.args.get("folder", "")
+    ).strip()
+    out = (
+        request.form.get("out", "") if request.method == "POST" else request.args.get("out", "")
+    ).strip()
+    message = ""
+    if request.method == "POST":
+        if not os.path.isdir(folder):
+            message = "Invalid source folder."
+        elif not out:
+            message = "Please specify output folder."
+        else:
+            try:
+                process(folder, out)
+                message = "Tagging complete."
+            except Exception as e:
+                message = str(e)
+    return render_template("dir_tagger.html", folder=folder, out=out, message=message)

--- a/templates/dir_tagger.html
+++ b/templates/dir_tagger.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Batch WD-Tagger</title>
+<style>
+  body { background: #111; color: #eee; font-family: sans-serif; padding: 2em; }
+  a { color: #4af; }
+  input[type=text] { padding: .4em; width: 80%; max-width: 600px; margin: .3em 0; }
+  input[type=submit] { padding: .5em 1.2em; margin: .3em 0; }
+</style>
+</head>
+<body>
+
+<h1>📦 Batch WD-Tagger</h1>
+<p>
+  <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
+  <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a> |
+  <a href="{{ url_for('metadata.metadata_page') }}">Switch to Metadata Extractor</a>
+</p>
+
+<form method="POST">
+  <input type="text" name="folder" placeholder="Image folder" value="{{ folder }}"><br>
+  <input type="text" name="out" placeholder="Output folder" value="{{ out }}"><br>
+  <input type="submit" value="Run">
+</form>
+
+{% if message %}<p>{{ message }}</p>{% endif %}
+
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,5 +38,6 @@
   <a class="btn" href="{{ url_for('tagger.tagger_page') }}">🏷️ WD-Tagger Organiser</a>
   <a class="btn" href="{{ url_for('rating.rating_page') }}">🔞 Rating Organiser</a>
   <a class="btn" href="{{ url_for('metadata.metadata_page') }}">📥 Metadata Extractor</a>
+  <a class="btn" href="{{ url_for('batch.batch_page') }}">📦 Batch WD-Tagger</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `/batch/` page for recursive WD-14 tagging
- update homepage to link to new page
- register new blueprint in `app.py`
- document the feature in README

## Testing
- `python -m py_compile app.py dir_tagger_routes.py tagger_routes.py prompt_routes.py rating_routes.py metadata_routes.py extract_metadata.py utils.py wd_batch_tagger.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511859dc8c8330800e5732fa2514ff