### PR TITLE
Ensure navigation to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The image organization script scans a specified source folder for images and mov
 ### extract_metadata.py
 
 - **Functionality**:
-  - Recursively scans a folder for PNG files.
+  - Recursively scans a folder for PNG files (other formats are ignored).
   - Extracts all available metadata from each image.
   - Saves the metadata to JSON files under a destination directory organised by rating (`general`, `sensitive`, `questionable`, `explicit`).
 - **Usage**:

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Extract metadata from PNG images and organize by rating."""
+"""Extract metadata from PNG images and organize by rating.
+
+Only ``.png`` files are processed; other formats are skipped.
+"""
 
 import argparse
 import json

--- a/metadata_routes.py
+++ b/metadata_routes.py
@@ -25,9 +25,17 @@ def metadata_page():
         elif not out:
             message = "Please specify output folder."
         else:
-            try:
-                extract_metadata.process(folder, out)
-                message = "Metadata extraction complete."
-            except Exception as e:
-                message = str(e)
+            pngs = [
+                f
+                for f in os.listdir(folder)
+                if os.path.splitext(f)[1].lower() == ".png"
+            ]
+            if not pngs:
+                message = "No PNG files found in source folder."
+            else:
+                try:
+                    extract_metadata.process(folder, out)
+                    message = "Metadata extraction complete."
+                except Exception as e:
+                    message = str(e)
     return render_template("metadata.html", folder=folder, out=out, message=message)

--- a/templates/dir_tagger.html
+++ b/templates/dir_tagger.html
@@ -14,6 +14,7 @@
 
 <h1>📦 Batch WD-Tagger</h1>
 <p>
+  <a href="{{ url_for('home') }}">Home</a> |
   <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
   <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a> |
   <a href="{{ url_for('metadata.metadata_page') }}">Switch to Metadata Extractor</a>

--- a/templates/metadata.html
+++ b/templates/metadata.html
@@ -14,13 +14,14 @@
 
 <h1>📥 Metadata Extractor</h1>
 <p>
+  <a href="{{ url_for('home') }}">Home</a> |
   <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
   <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a> |
   <a href="{{ url_for('rating.rating_page') }}">Switch to Rating Organiser</a>
 </p>
 
 <form method="POST">
-  <input type="text" name="folder" placeholder="Image folder" value="{{ folder }}"><br>
+  <input type="text" name="folder" placeholder="PNG image folder" value="{{ folder }}"><br>
   <input type="text" name="out" placeholder="Destination folder" value="{{ out }}"><br>
   <input type="submit" value="Extract">
 </form>

--- a/templates/prompt.html
+++ b/templates/prompt.html
@@ -20,7 +20,10 @@
 <body>
 
 <h1>🖼️ Prompt Organiser</h1>
-<p><a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a></p>
+<p>
+  <a href="{{ url_for('home') }}">Home</a> |
+  <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a>
+</p>
 
 <!-- Folder scan form -->
 <form method="POST">

--- a/templates/rating.html
+++ b/templates/rating.html
@@ -23,6 +23,7 @@
 
 <h1>🔞 Rating Organiser</h1>
 <p>
+  <a href="{{ url_for('home') }}">Home</a> |
   <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a> |
   <a href="{{ url_for('tagger.tagger_page') }}">Switch to WD-Tagger Organiser</a>
 </p>

--- a/templates/tagger.html
+++ b/templates/tagger.html
@@ -23,7 +23,10 @@
 <body>
 
 <h1>🏷️ WD-Tagger Organiser</h1>
-<p><a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a></p>
+<p>
+  <a href="{{ url_for('home') }}">Home</a> |
+  <a href="{{ url_for('prompt.prompt_page') }}">Switch to Prompt Organiser</a>
+</p>
 
 <form method="POST">
   <input type="text" name="folder" placeholder="Full path to image folder" value="{{ folder }}"><br>


### PR DESCRIPTION
## Summary
- add a "Home" link to all feature pages
- restrict metadata extractor to .png files only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685121369e40833087fc70ab8cf7ffed